### PR TITLE
Improve IP lookup with browser DNS resolve

### DIFF
--- a/background.js
+++ b/background.js
@@ -32,6 +32,15 @@ browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
 // Function that uses an external API for IP lookup
 async function fetchIPFromAPI(hostname) {
   try {
+    // Method 0: browser DNS lookup
+    const result = await browser.dns.resolve(hostname, ['disable_trr']);
+    if (result && result.addresses && result.addresses.length) {
+      return result.addresses[0];
+    }
+  } catch (e) {
+    console.log('browser.dns.resolve failed');
+  }
+  try {
     // Method 1: use ipapi.co
     const response1 = await fetch(`https://ipapi.co/${hostname}/json/`, {
       headers: {


### PR DESCRIPTION
## Notes
- Added a new attempt in `fetchIPFromAPI` that uses `browser.dns.resolve` before falling back to external services.
- External APIs remain as fallback options and the IP is still cached.

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_683dab87f5ac832589c82faa43295e7d